### PR TITLE
fmt/2092: new RTF 1 fallback format

### DIFF
--- a/signatures/fmt/2092.json
+++ b/signatures/fmt/2092.json
@@ -1,21 +1,21 @@
 {
-  "fileFormatID": 631,
+  "fileFormatID": 3969,
   "formatName": "Rich Text Format",
-  "version": "1.5-1.6",
-  "formatDescription": "Rich Text Format (RTF) is a format developed by Microsoft to encode formatted text and graphics for use within applications or for data and formatting transfer between applications. It is closely associated with Microsoft Word, and new versions are developed with each release of Word. RTF files are encoded in plain text, typically ASCII, and consists of a series of control words, control symbols and groups. An RTF file comprises a Header section, containing various header tables, followed by a Document section, containing the document content and formatting. RTF version 1.5 is the version of the format associated with Microsoft Word 97, and introduced partially Unicode support.",
+  "version": "1",
+  "formatDescription": "Rich Text Format (RTF) is a format developed by Microsoft to encode formatted text and graphics for use within applications or for data and formatting transfer between applications. It is closely associated with Microsoft Word, and new versions are developed with each release of Word. RTF files are encoded in plain text, typically ASCII, and consists of a series of control words, control symbols and groups. An RTF file comprises a Header section, generally containing various header tables, followed by a Document section, containing the document content and formatting.",
   "releaseDate": null,
   "withdrawnDate": null,
   "binaryFileFormat": "Text",
-  "formatNote": null,
-  "lastUpdatedDate": "02 Aug 2005",
+  "formatNote": "This is a fallback entry covering the entire RTF 1 family, matching only the \\rtf1 control word. While headers that consist only of \\rtf1 are technically valid according to the RTF 1.9 specification, modern applications such as Microsoft Word and LibreOffice are not known to produce such minimal headers. Hence, files matching only this signature are ambigious: they may be genuine RTF 1.9 files, or more likely, files that were meant to conform to an earlier RTF version, but with required parts of the header omitted.",
+  "lastUpdatedDate": null,
   "formatSourceID": 1,
   "provenanceCompoundName": "Digital Preservation Department / The National Archives",
   "formatProvenance": null,
-  "formatSourceDate": "11 Mar 2005",
+  "formatSourceDate": null,
   "formatDisclosure": "Full",
   "formatEnvironment": null,
   "formatRisk": null,
-  "formatAliases": "RTF (1.5), RTF (97)",
+  "formatAliases": "RTF (1)",
   "formatTypes": "Word Processor",
   "byteOrders": null,
   "formatFamilies": "Rich Text Format",
@@ -25,29 +25,29 @@
       "identifierType": "MIME"
     },
     {
-      "identifierText": "fmt/50",
+      "identifierText": "fmt/2092",
       "identifierType": "PUID"
-    },
-    {
-      "identifierText": "public.rtf",
-      "identifierType": "Apple Uniform Type Identifier"
     },
     {
       "identifierText": "text/rtf",
       "identifierType": "MIME"
+    },
+    {
+      "identifierText": "public.rtf",
+      "identifierType": "Apple Uniform Type Identifier"
     }
   ],
   "internalSignatures": [
     {
-      "signatureID": 158,
-      "name": "RTF 1.5 - 1.6 (generic)",
-      "note": "\\rtf control word, \\ansicpg control word",
+      "signatureID": 3455,
+      "name": "RTF 1.x (generic fallback)",
+      "note": "\\rtf1 control word",
       "byteSequences": [
         {
           "positionType": "Absolute from BOF",
           "offset": 0,
           "maxOffset": null,
-          "byteSequence": "7B5C7274(66|6631){0-1}5C(616E7369|6D6163|7063|706361)5C616E7369637067",
+          "byteSequence": "7B5C72746631",
           "endianness": null
         }
       ]
@@ -62,6 +62,16 @@
   "relationships": [
     {
       "relationshipType": "Has lower priority than",
+      "relatedFormatID": 626,
+      "relatedFormatName": "Rich Text Format"
+    },
+    {
+      "relationshipType": "Has lower priority than",
+      "relatedFormatID": 631,
+      "relatedFormatName": "Rich Text Format"
+    },
+    {
+      "relationshipType": "Has lower priority than",
       "relatedFormatID": 633,
       "relatedFormatName": "Rich Text Format"
     },
@@ -73,11 +83,6 @@
     {
       "relationshipType": "Has lower priority than",
       "relatedFormatID": 1101,
-      "relatedFormatName": "Rich Text Format"
-    },
-    {
-      "relationshipType": "Has priority over",
-      "relatedFormatID": 626,
       "relatedFormatName": "Rich Text Format"
     },
     {
@@ -102,17 +107,12 @@
     },
     {
       "relationshipType": "Has priority over",
-      "relatedFormatID": 3969,
-      "relatedFormatName": "Rich Text Format"
-    },
-    {
-      "relationshipType": "Is previous version of",
       "relatedFormatID": 632,
       "relatedFormatName": "Rich Text Format"
     },
     {
       "relationshipType": "Is subsequent version of",
-      "relatedFormatID": 630,
+      "relatedFormatID": 1174,
       "relatedFormatName": "Rich Text Format"
     }
   ],

--- a/signatures/fmt/2092.json
+++ b/signatures/fmt/2092.json
@@ -112,7 +112,7 @@
     },
     {
       "relationshipType": "Is subsequent version of",
-      "relatedFormatID": 1174,
+      "relatedFormatID": 1774,
       "relatedFormatName": "Rich Text Format"
     }
   ],

--- a/signatures/fmt/355.json
+++ b/signatures/fmt/355.json
@@ -106,6 +106,11 @@
       "relatedFormatName": "Rich Text Format"
     },
     {
+      "relationshipType": "Has priority over",
+      "relatedFormatID": 3969,
+      "relatedFormatName": "Rich Text Format"
+    },
+    {
       "relationshipType": "Is subsequent version of",
       "relatedFormatID": 753,
       "relatedFormatName": "Rich Text Format"

--- a/signatures/fmt/45.json
+++ b/signatures/fmt/45.json
@@ -81,6 +81,11 @@
       "relatedFormatName": "Rich Text Format"
     },
     {
+      "relationshipType": "Has priority over",
+      "relatedFormatID": 3969,
+      "relatedFormatName": "Rich Text Format"
+    },
+    {
       "relationshipType": "Is previous version of",
       "relatedFormatID": 627,
       "relatedFormatName": "Rich Text Format"

--- a/signatures/fmt/52.json
+++ b/signatures/fmt/52.json
@@ -106,6 +106,11 @@
       "relatedFormatName": "Rich Text Format"
     },
     {
+      "relationshipType": "Has priority over",
+      "relatedFormatID": 3969,
+      "relatedFormatName": "Rich Text Format"
+    },
+    {
       "relationshipType": "Is previous version of",
       "relatedFormatID": 753,
       "relatedFormatName": "Rich Text Format"

--- a/signatures/fmt/53.json
+++ b/signatures/fmt/53.json
@@ -106,6 +106,11 @@
       "relatedFormatName": "Rich Text Format"
     },
     {
+      "relationshipType": "Has priority over",
+      "relatedFormatID": 3969,
+      "relatedFormatName": "Rich Text Format"
+    },
+    {
       "relationshipType": "Is previous version of",
       "relatedFormatID": 1101,
       "relatedFormatName": "Rich Text Format"


### PR DESCRIPTION
You thought RTF was dead? Think again! I recently came across some strange-but-valid RTF files, created around 2015 or so.  My findings about these files and the RTF spec seemed worth sharing.

# Problem

Currently, the `byteSequences` of the RTF PRONOM entries becomes progressively more specific,  with  1.0 being short and general, and with 1.9 being a long compound of rules: 

```json
  "formatName": "Rich Text Format",
  "version": "1.9",
  ...
      "byteSequences": [
        {
          "positionType": "Absolute from BOF",
          "offset": 0,
          "maxOffset": null,
          "byteSequence": "7B5C7274(66|6631){0-15}(616E7369|6D6163|7063|706361)5C616E7369637067{3-*}5C737473686664626368{1-5}5C73747368666C6F6368{1-5}5C737473686668696368{1-5}5C73747368666269*5C(2A5C636F6C6F72736368656D656D617070696E67|6166656C6576|2A5C6461746173746F7265|2A5C646566636870)",
```

I could be wrong here, but after studying the official RTF 1.9 spec, I've concluded that rather than being the RTF version with the most restrictive header rules, its actually the most lenient. In fact, I can cite some excerpts that show that smallest valid RTF 1.9 header is just the string `\rtf1`!

`file` (i.e. libmagic) supports this contention, FWIW:

``` shellsession
$ echo '{\rtf1}' > /tmp/t.rtf 
$ file /tmp/t.rtf
/tmp/t.rtf: Rich Text Format data, version 1
```

## RTF 1.9 spec and the introduction of  minimal headers

To cite from page 12 [of the 1.9 spec](https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxrtfcp/85c0b884-a960-4d1a-874e-53eeee527ca6):


> The header has the following syntax:

> ```
> <header>	\rtf1 \fbidis? <character set> <from>? <deffont> <deflang> <fonttbl>? <filetbl>? <colortbl>?
>			    <stylesheet>? <stylerestrictions>? <listtables>? <revtbl>? <rsidtable>? <mathprops>? <generator>?
> ```

What all of this means is largely irrelevant — we only need to know that `<foo>?` indicates an optional element.

That leaves `<character set>`, `<deffont>`, and `<deflang>` as seemingly required elements. 

Yet, if we read further, we see that each of these may expand to the empty string. For starters, let's look at `<character set>`:

> ## Character set

 > After specifying the RTF version, you must declare the default character set used in the document **unless it is `\ansi` (the default)**. [emphasis mine] The RTF Specification supports the following document character sets:
 
> ```
> <character set>   (\ansi | \mac | \pc | \pca)? \ansicpgN?
> ```

Note the `?`, indicating that a given element is optional. Note also that the caveat "unless it is `\ansi`..."  [is absent in the 1.8 spec](http://ysagnier.free.fr/formats/rtf/rtf-spec-1-8.pdf) (p. 7), which is otherwise worded almost exactly the same .

Finally, on page 13 we see that both `<deffont>` and `<deflang>` may also expand to the empty string:

> ```
> <deffont>	\deffN? \adeffN? (\stshfdbchN \stshflochN \stshfhichN \stshfbiN)?
> <deflang>	\deflangN? \deflangfeN? \adeflangN?
> ```

Here, the spec 1.9 is again noticably more lenient than 1.8. 

My guess is that the final RTF spec became more lenient to deal with lazy RTF producers, similar to how early undefined and lazily-written HTML would eventually become valid years later. 

# Proposal & rationale

I've come across some files —  HTML emails from around 2015 that have been converted to RTF — with an extremely minimal RTF header (see "Samples" section). They are currently not detected as RTF files by PRONOM-detection programs such as `sf`.


Still, these files (1) are obviously _intended_ as RTF1 files, (2) are technically valid RTF 1.9,  (3) are recognized as part of the RTF1 family by libmagic, and (4) can be opened without error by modern RTF-readers like LibreOffice. So, I think the current RTF PRONOM entries ought to be revisited — the argument that the files in my sample are in fact RTF files seems pretty strong. 

My proposed solution (see the PR) is to define a fallback format. It's fairly generic, in the sense that it only looks for evidence of RTF _major_ version 1,  and is only triggered after the current RTF entries have failed to find evidence for  a specific _minor_ version.  All versions of the RTF spec consider the string `\rtf1` as evidence of the 1.x major version (RTF 1.9; p. 13): 

>  The `\rtfN` control word must follow the opening brace. The numeric parameter `N` identifies the major version of the RTF Specification used. The RTF standard described in this specification, although titled as version 1.9.1, continues to correspond syntactically to RTF Specification version 1. 

One thing I do not like about my solution is that PRONOM entries that define fallbacks are, as far as I could find, either non-existent or rare. Hence, users might not expect to encounter a general fallback format. A possible prior example is [the RTF0 PRONOM entry](https://github.com/nationalarchives/pronom-signatures/blob/develop/signatures/fmt/969.json), however, which I've tried to model after.

## Alternatives

You could argue that encountering a minimal header is actually positive evidence of a file being RTF 1.9. I've considered modifying the RTF 1.9 entry to reflect this, but ultimately decided against this.

The reason why this approach seemed inferior has to do with [part of PRONOM's mission](https://www.nationalarchives.gov.uk/aboutapps/pronom/): 

> Technical information about the structure of those file formats, and the **software products which support them**, is ... a prerequisite for any digital preservation regime

We want to know if a file uses some crazy 'RTF 1.9'-only features, so that we may know how it can be opened, converted, etc. If we _entirely replace_ the current signature by a super generic one, we would lose the ability to confidently say  "this RTF file needs a reader that supports features X, Y, Z, ...". 

A workaround would be to have two RTF 1.9 signatures, one that is specific and has an extremely high priority (i.e.  the status quo), and one that is extremely generic and has lower priority than all other RTF 1.x formats. That way, we first check for RTF 1.9 specific features, then for features specific to older RTF versions, and if all of that fails, treat the file as a minimal RTF 1.9 file.  However, this is currently not possible to express in the schema language, since `relationships`  cannot be applied to a particular internal signature:

```json
  "internalSignatures": [
    {
      "signatureID": 3455,
      "name": "RTF 1.9 (minimal header)",
       ...
      "byteSequences": [
        {
          "positionType": "Absolute from BOF",
          ...
          "byteSequence": "7B5C72746631"
        }
        # we cannot define a priority here 😔
      ]
```

I also suspect that a super generic RTF 1.9 signature would create a lot of false positives on older, malformed RTF files. This is not a problem with the current approach, which only says that they are part of the RTF1 family, rather than a more specific and potentially false claim. 

# Samples

These samples were collected and researched during my job at [Regionaal Archief Rivierenland](https://github.com/Regionaal-Archief-Rivierenland), a Dutch regional archive (not super relevant, but I've noticed you generally list this info for every new format 😉). 

Unfortunately, I cannot share any of the files as-is, since they are part of a classified collection. Instead, I've attached a redacted version of one RTF file.   

[Informeel uitje vrijdag 20 juni 2014.rtf.zip](https://github.com/user-attachments/files/25776820/Informeel.uitje.vrijdag.20.juni.2014.rtf.zip)

Below, you will also find what some of the headers in this collection look like.

Notice how `{\colortbl;\red0\green0\blue0;}` is still part of this otherwise sparse header. This is an optional but valid header element, meaning that these files cannot be explained away as having their header completely corrupted away:  

```shellsession
$ rg '\\\rtf1'
Informeel uitje vrijdag 20 juni 2014.rtf
1:{\rtf1 {\colortbl;\red0\green0\blue0;}\pard\tx1500\tx3000\plain\fs16\cf1\b1 Van:\b0\tab Ondernemers Vereniging Neerijnen<REDACTED@REDACTED.nl>\par

Opvoedweek  gemeente Neerijnen.rtf
1:{\rtf1 {\colortbl;\red0\green0\blue0;}\pard\tx1500\tx3000\plain\fs16\cf1\b1 Van:\b0\tab Stichting ... <REDACTED@REDACTED.com>\par

RE Kosten vervanging dak REDACTED.rtf1:
1:{\rtf1 {\colortbl;\red0\green0\blue0;}\pard\tx1500\tx3000\plain\fs16\cf1\b1 Van:\b0\tab Jos de REDACTED <j.REDACTED@REDACTED.nl>\par
```

There are more files in this archive like this (and also some files that have richer headers), but you get the idea. See the attachment for a complete file.

If I compile the JSON in this PR to a binary signature, these files are now detected correctly, instead of returning no results at all:

```
sf "Betr. Raadsvragen GBN REDACTED.rtf"
---
siegfried   : 1.11.2
scandate    : 2026-03-05T18:22:27+01:00
signature   : default.sig
created     : 2026-03-05T16:01:40+01:00
identifiers : 
  - name    : 'pronom'
    details : 'signature-file.xml; container-signature-file.xml; built without reports'
---
filename : 'Betr. Raadsvragen GBN REDACTED.rtf'
filesize : 109
modified : 2026-03-05T16:05:39+01:00
errors   : 
matches  :
  - ns      : 'pronom'
    id      : 'fmt/2092'
    format  : 'Rich Text Format'
    version : '1'
    mime    : 'application/rtf'
    basis   : 'extension match rtf; byte match at 0, 6'
    warning : 
```

Since this general RTF1 fallback format has extremely low priority, detection results on other RTF files stay the same. 


---- 

Sorry for not following the submission instructions in the README to the letter btw. I somewhat ignored them because I assumed that they may be outdated (there is no submissions folder, for one). 